### PR TITLE
file-sort: try to debug differences

### DIFF
--- a/dev/file-sort/.gitignore
+++ b/dev/file-sort/.gitignore
@@ -3,3 +3,4 @@
 /.lein-*
 /.nrepl-port
 /.prepl-port
+_data

--- a/dev/file-sort/src/t/core.clj
+++ b/dev/file-sort/src/t/core.clj
@@ -26,7 +26,9 @@
   [root]
   (->> (Paths/get root (make-array String 0))
        no-sym-file-seq
-       count))
+       (map (fn [^Path p] (-> p .toAbsolutePath .toString)))
+       (map println)
+       doall))
 
 (defn -main
   [& args]
@@ -36,5 +38,4 @@
           (println "list of paths to folders to analyze and track."))
       (->> (string/split env_roots #" ")
            (map count-files)
-           (reduce + 0)
-           prn))))
+           doall))))


### PR DESCRIPTION
print all files instead of just count

compare

```
find /Volumes/to_sort /Volumes/TOSHIBA ~/Downloads ~/Desktop  -type f | sort > _data/find
```

with

```
lein run | sort > _data/clj
```

to try to figure out why 2159132 vs. 1828032.