### PR TITLE
books/2015/pawga/ch4: add model events

### DIFF
--- a/books/2015/pro-android-web-game-apps-2012/cljs/src/main/ch4/main.cljs
+++ b/books/2015/pro-android-web-game-apps-2012/cljs/src/main/ch4/main.cljs
@@ -77,6 +77,20 @@
                                                [[:sprite x y img]])))
                              (recur))))))))
 
+(defn start-model-loop!
+  [>bus]
+  (async/go
+    (let [_ (async/>! >bus [:anim (fn [t] [[:knight 0 200 :standing :right]])])
+          _ (async/<! (async/timeout 1000))
+          t1 (js/performance.now)
+          _ (async/>! >bus [:anim (fn [t]
+                                    (let [t (- t t1)]
+                                      [[:knight (quot t 100) 200 :walking :right]]))])
+          _ (async/<! (async/timeout 1000))
+          t2 (js/performance.now)
+          x (quot (- t2 t1) 100)
+          _ (async/>! >bus [:anim (fn [t] [[:knight x 200 :standing :right]])])])))
+
 (defn init
   []
   (let [>bus (async/chan)


### PR DESCRIPTION
Completely disconnected from everything at this point. I was worried the diff may be too big otherwise. The idea is to simulate a separate model loop that:

- Maintains the state of the game.
- Collects user input and updates the model accordingly.

I'm thinking for now this "game" will just be a knight moving on arrow keys. So on right-arrow down, the model should emit a "animodel" that is a function of time to the knight having moved, and on right-arrow up, the model should emit a new animodel where the knight does not move anymore, but has the same final position as displayed.

So this stub here is simulating a user that waits for a second when the page loads, then presses the right arrow key for one second and then releases it.