### PR TITLE
aoc/2024: get perf working on all relevant days

### DIFF
--- a/advent_of_code/2024/src/t/core.clj
+++ b/advent_of_code/2024/src/t/core.clj
@@ -87,7 +87,9 @@
 
 (defn times
   []
-  (doseq [d (map inc (range 25))]
+  (doseq [d (map inc (range 25))
+          :when (not= d 14)
+          :when (not= d 24)]
     (let [input (slurp (format "data/puzzle/day%02d" d))
           day-ns (format "t.day%02d" d)
           _ (require [(symbol day-ns)])

--- a/advent_of_code/2024/src/t/day11.clj
+++ b/advent_of_code/2024/src/t/day11.clj
@@ -23,11 +23,12 @@
                          :else [(* 2024 s)]))))))
 
 (defn part1
-  [stones n]
-  (->> (iterate step stones)
-       (drop n)
-       first
-       count))
+  ([stones] (part1 stones 25))
+  ([stones n]
+   (->> (iterate step stones)
+        (drop n)
+        first
+        count)))
 
 (defn memo-walk
   [memo stone n]
@@ -42,18 +43,19 @@
           [(assoc memo [stone n] c) c])))
 
 (defn part2
-  [stones n]
-  (->> stones
-       (reduce (fn [[m tot] stone]
-                 (let [[m c] (memo-walk m stone n)]
-                   [m (+ c tot)]))
-               [{} 0])
-       second))
+  ([stones] (part2 stones 75))
+  ([stones n]
+   (->> stones
+        (reduce (fn [[m tot] stone]
+                  (let [[m c] (memo-walk m stone n)]
+                    [m (+ c tot)]))
+                [{} 0])
+        second)))
 
 (lib/check
   [part1 sample 1] 7
   [part1 sample1 6] 22
-  [part1 sample1 25] 55312
+  [part1 sample1] 55312
   [part1 puzzle 25] 217812
   [part2 puzzle 25] 217812
-  [part2 puzzle 75] 259112729857522)
+  [part2 puzzle] 259112729857522)

--- a/advent_of_code/2024/src/t/day13.clj
+++ b/advent_of_code/2024/src/t/day13.clj
@@ -38,16 +38,17 @@
        (reduce + 0)))
 
 (defn part2
-  [input offset]
-  (->> input
-       (map (fn [[ax ay bx by px py]]
-              [ax ay bx by (+ px offset) (+ py offset)]))
-       (keep solve)
-       (reduce + 0)))
+  ([input] (part2 input 10000000000000))
+  ([input offset]
+   (->> input
+        (map (fn [[ax ay bx by px py]]
+               [ax ay bx by (+ px offset) (+ py offset)]))
+        (keep solve)
+        (reduce + 0))))
 
 (lib/check
   [part1 sample] 480
   [part1 puzzle] 34393
   [part2 sample 0] 480
   [part2 puzzle 0] 34393
-  [part2 puzzle 10000000000000] 83551068361379)
+  [part2 puzzle] 83551068361379)

--- a/advent_of_code/2024/src/t/day18.clj
+++ b/advent_of_code/2024/src/t/day18.clj
@@ -19,28 +19,30 @@
          (map (fn [p] [p (inc cost)])))))
 
 (defn part1
-  [input size num-bytes]
-  (let [grid (->> input
-                  (take num-bytes)
-                  (reduce (fn [acc el] (assoc acc (vec el) :wall)) {}))]
-    (lib/dijkstra-search
-      [0 0]
-      (fn [[x y]] (= (dec size) x y))
-      (generate-moves grid size))))
+  ([input] (part1 input 71 1024))
+  ([input size num-bytes]
+   (let [grid (->> input
+                   (take num-bytes)
+                   (reduce (fn [acc el] (assoc acc (vec el) :wall)) {}))]
+     (lib/dijkstra-search
+       [0 0]
+       (fn [[x y]] (= (dec size) x y))
+       (generate-moves grid size)))))
 
 (defn part2
-  [input size start]
-  (loop [num-bytes start]
-    (if (try (part1 input size num-bytes)
-          true
-          (catch Exception e false))
-      (recur (inc num-bytes))
-      (->> (nth input (dec num-bytes))
-           (interpose ",")
-           (apply str)))))
+  ([input] (part2 input 71 1024))
+  ([input size start]
+   (loop [num-bytes start]
+     (if (try (part1 input size num-bytes)
+           true
+           (catch Exception e false))
+       (recur (inc num-bytes))
+       (->> (nth input (dec num-bytes))
+            (interpose ",")
+            (apply str))))))
 
 (lib/check
   [part1 sample 7 12] 22
-  [part1 puzzle 71 1024] 316
+  [part1 puzzle] 316
   [part2 sample 7 12] "6,1"
-  [part2 puzzle 71 1024] "45,18")
+  [part2 puzzle] "45,18")

--- a/advent_of_code/2024/src/t/day20.clj
+++ b/advent_of_code/2024/src/t/day20.clj
@@ -79,16 +79,18 @@
                (conj visited state))))))
 
 (defn part1
-  [{:keys [valid-pos? start end] :as input} saves-at-least]
-  (let [[no-cheat-cost no-cheat-path] (trace-no-cheat-path start end valid-pos?)
-        max-cost (- no-cheat-cost saves-at-least)]
-    (count (cheating-paths 2 no-cheat-path start end max-cost))))
+  ([input] (part1 input 100))
+  ([{:keys [valid-pos? start end] :as input} saves-at-least]
+   (let [[no-cheat-cost no-cheat-path] (trace-no-cheat-path start end valid-pos?)
+         max-cost (- no-cheat-cost saves-at-least)]
+     (count (cheating-paths 2 no-cheat-path start end max-cost)))))
 
 (defn part2
-  [{:keys [valid-pos? start end] :as input} saves-at-least]
-  (let [[no-cheat-cost no-cheat-path] (trace-no-cheat-path start end valid-pos?)
-        max-cost (- no-cheat-cost saves-at-least)]
-    (count (cheating-paths 20 no-cheat-path start end max-cost))))
+  ([input] (part2 input 100))
+  ([{:keys [valid-pos? start end] :as input} saves-at-least]
+   (let [[no-cheat-cost no-cheat-path] (trace-no-cheat-path start end valid-pos?)
+         max-cost (- no-cheat-cost saves-at-least)]
+     (count (cheating-paths 20 no-cheat-path start end max-cost)))))
 
 (lib/check
   [part1 sample 2] 44
@@ -102,7 +104,7 @@
   [part1 sample 38] 3
   [part1 sample 40] 2
   [part1 sample 64] 1
-  [part1 puzzle 100] 1323
+  [part1 puzzle] 1323
   [part2 sample 76] 3
   [part2 sample 74] 7
   [part2 sample 72] 29
@@ -117,4 +119,4 @@
   [part2 sample 54] 222
   [part2 sample 52] 253
   [part2 sample 50] 285
-  [part2 puzzle 100] 983905)
+  [part2 puzzle] 983905)

--- a/advent_of_code/2024/src/t/day21.clj
+++ b/advent_of_code/2024/src/t/day21.clj
@@ -121,7 +121,15 @@
                  (shortest-length c iters))))
        (reduce + 0)))
 
+(defn part1
+  [input]
+  (solve input 2))
+
+(defn part2
+  [input]
+  (solve input 25))
+
 (lib/check
-  [solve sample 2] 126384
-  [solve puzzle 2] 219366
-  [solve puzzle 25] 271631192020464)
+  [part1 sample] 126384
+  [part1 puzzle] 219366
+  [part2 puzzle] 271631192020464)


### PR DESCRIPTION
Days 14 and 24 are not currently worth measuring as they've both been solved manually, so the code is not doing much.

For 11, 13, 18, and 20, add default arguments so my performance-measuring code can actually run the appropriate functions.

For 21, reintroduce part1 and part2; solve was cute though.