### PR TITLE
proglang: move path definition to deps.edn

### DIFF
--- a/dev/proglang/bin/h
+++ b/dev/proglang/bin/h
@@ -19,7 +19,7 @@ _test() (
 )
 
 _repl() (
-  clj -Sdeps '{:paths ["src" "test"]}' -M:cider-clj
+  clj -M:cider-clj
 )
 
 case $1 in

--- a/dev/proglang/deps.edn
+++ b/dev/proglang/deps.edn
@@ -1,7 +1,12 @@
 {:deps
  {instaparse/instaparse {:mvn/version "1.5.0"}}
  :aliases
- {:test {:extra-paths ["test"]
+ {:cider-clj {:extra-deps {org.clojure/clojure {:mvn/version "1.12.1"}
+                          cider/cider-nrepl {:mvn/version "0.56.0"}
+                          fipp/fipp {:mvn/version "0.6.27"}}
+              :extra-paths ["test"]
+              :main-opts ["-m" "nrepl.cmdline" "--middleware" "[cider.nrepl/cider-middleware]"]}
+  :test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
          :main-opts ["-m" "cognitect.test-runner"]
          :exec-fn cognitect.test-runner.api/test}}}


### PR DESCRIPTION
Still figuring things out, obviously. I thought it was a bit weird to
have the REPL src path defined in `h` rather than in `deps.edn`, but
that required moving the `cider-clj` alias to the project itself, which
I'm not entirely sure how I feel about.

Maybe I should instead add the `:extra-paths` key to
`~/.clojure/deps.edn`? :thinking: