### PR TITLE
proglang: batch test

### DIFF
--- a/dev/proglang/bin/h
+++ b/dev/proglang/bin/h
@@ -15,7 +15,7 @@ _help() (
 )
 
 _test() (
-  fswatch . | xargs -n 1 bash -c 'clj -X:test'
+  fswatch -o -0 . | xargs -0 -n 1 bash -c 'clj -X:test'
 )
 
 _repl() (


### PR DESCRIPTION
The `-0` flag on both sides separates filenames with the `NUL` character
rather than space, meaning this will not break should I decide to use
pases in my filenames at some point.

The `o` flag instructs `fswatch` to batch events, reducing the number of
times my tests run.