### PR TITLE
proglang: refactor grammar

### DIFF
--- a/dev/proglang/src/main.clj
+++ b/dev/proglang/src/main.clj
@@ -5,10 +5,11 @@
 (def parse
   (insta/parser
     "S = expr
-     <expr> = <w> (int | pexpr | sum | product) <w>
+     <expr> = <w> (atom | sum | product) <w>
+     <atom> = int | pexpr
      <pexpr> = <'('> <w> expr <w> <')'>
-     sum = (int | pexpr | product) (<w> <'+'> <w> (int | pexpr | product))+
-     product = (int | pexpr) (<w> <'*'> <w> (int | pexpr))+
+     sum = (atom | product) (<w> <'+'> <w> (atom | product))+
+     product = atom (<w> <'*'> <w> atom)+
      int = #'\\d+'
      w = #'\\s'*"))
 


### PR DESCRIPTION
As we develop the language, we will be adding new types of atoms, which
will be a bit easier to do if atoms are explicitly part of the grammar.