### PR TITLE
gity/minj: try to set environment

### DIFF
--- a/dev/gity/java-only/.envrc
+++ b/dev/gity/java-only/.envrc
@@ -1,19 +1,13 @@
-export NIX_CONFIG="experimental-features = nix-command flakes"
+xcode=$(xcode-select -p)
 use nix
+PATH_add $xcode/usr/bin
+PATH_add /usr/bin
+
+export DEVELOPER_DIR=$xcode
+export CC=$xcode/usr/bin/clang
+export CXX=$xcode/usr/bin/clang++
+export SDKROOT=$xcode/SDKs/MacOSX.sdk
+
 watch_file nix/src.json
 
 PATH_add bin
-
-source_env_if_exists .envrc.private
-
-# If using Python, uncomment to get direnv to activate venv - otherwise, delete
-# lock=$(sha256sum requirements.txt 2>&1)
-# if ! [ -f .venv/lock ] || [ "$(cat .venv/lock)" != "$lock" ]; then (
-#   rm -rf .venv
-#   python3 -m venv .venv
-#   source .venv/bin/activate
-#   echo "$lock" > .venv/lock
-#   python -m pip install -r requirements.txt
-# ) fi
-#
-# source .venv/bin/activate

--- a/dev/gity/java-only/bin/build
+++ b/dev/gity/java-only/bin/build
@@ -5,4 +5,4 @@ DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 cd "$DIR/.."
 
 javac MinimalSwingApp.java
-native-image -H:-CheckToolchain MinimalSwingApp
+native-image MinimalSwingApp -H:+UnlockExperimentalVMOptions -H:CCompilerPath="$CC"

--- a/dev/gity/java-only/shell.nix
+++ b/dev/gity/java-only/shell.nix
@@ -1,6 +1,5 @@
 let
   pkgs = import ./nix/nixpkgs.nix {};
-  getFlake = url: (builtins.getFlake url).packages.${pkgs.system}.default;
 in
 pkgs.mkShell {
   LOCALE_ARCHIVE = if pkgs.stdenv.isLinux then "${pkgs.glibcLocales}/lib/locale/locale-archive" else "";


### PR DESCRIPTION
So the next step was to try to get `native-image` to use the host
toolchains rather than the Nix-provided one. This was a lot harder than
I expected. I tried many different approaches: various flags to
`native-image`, setting env vars from the `shell.nix` file, setting env
vars in `.envrc`, etc. It took a while. I also took a detour through
trying to pass explicit linker options to the toolchain through
`native-image` flags, which added its own fun minigame of "guess the
parser". Setting the compiler path explicitly (`-H:CCompilerPath="$CC"`,
with `CC` properly defined) resulted in a compiler that fails to find
`stdio.h`.

It has the additional hurdle of giving me a crippled `vim` by putting
`/usr/bin` at the front of the `PATH`, though things don't seem to work
without that. Things don't seem to work with that either, really, as the
build at this point produces:

```
$ build
Warning: Environment variable 'MACOSX_DEPLOYMENT_TARGET_FOR_TARGET' is undefined and therefore not available during image build-time.
Warning: Environment variable 'DEVELOPER_DIR_FOR_BUILD' is undefined and therefore not available during image build-time.
Warning: Environment variable 'DEVELOPER_DIR_FOR_TARGET' is undefined and therefore not available during image build-time.
Warning: Environment variable 'MACOSX_DEPLOYMENT_TARGET_FOR_BUILD' is undefined and therefore not available during image build-time.
Warning: Environment variable 'NIX_BUILD_TOP' is undefined and therefore not available during image build-time.
========================================================================================================================
GraalVM Native Image: Generating 'minimalswingapp' (executable)...
========================================================================================================================
[1/8] Initializing...
                                                                                    (0,0s @ 0,06GB)
Error: Error compiling query code (in /var/folders/t8/rqf91gfx4f77klq09d1ptl9h0000gn/T/SVM-15713958073275293701/RISCV64LibCHelperDirectives.c). Compiler command '/Library/Developer/CommandLineTools/usr/bin/clang -Wall -Werror -Wno-tautological-compare -o /var/folders/t8/rqf91gfx4f77klq09d1ptl9h0000gn/T/SVM-15713958073275293701/RISCV64LibCHelperDirectives /var/folders/t8/rqf91gfx4f77klq09d1ptl9h0000gn/T/SVM-15713958073275293701/RISCV64LibCHelperDirectives.c' output included error: /var/folders/t8/rqf91gfx4f77klq09d1ptl9h0000gn/T/SVM-15713958073275293701/RISCV64LibCHelperDirectives.c:1:10: fatal error: 'stdio.h' file not found
    C file contents around line 1:
    /var/folders/t8/rqf91gfx4f77klq09d1ptl9h0000gn/T/SVM-15713958073275293701/RISCV64LibCHelperDirectives.c:1: #include <stdio.h>
    /var/folders/t8/rqf91gfx4f77klq09d1ptl9h0000gn/T/SVM-15713958073275293701/RISCV64LibCHelperDirectives.c:2: #include <stddef.h>
------------------------------------------------------------------------------------------------------------------------
                         0,1s (3,7% of total time) in 5 GCs | Peak RSS: 0,40GB | CPU load: 2,70
========================================================================================================================
Failed generating 'minimalswingapp' after 1,0s.
$
```