### PR TITLE
gity/minj: trying to resolve compiler libs

### DIFF
--- a/dev/gity/java-only/bin/build
+++ b/dev/gity/java-only/bin/build
@@ -4,5 +4,14 @@ set -euo pipefail
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 cd "$DIR/.."
 
+SDK_PATH=$(xcrun --sdk macosx --show-sdk-path | xargs)
+echo "Resolved SDK Path (trimmed): \"$SDK_PATH\""
+
 javac MinimalSwingApp.java
-native-image MinimalSwingApp -H:+UnlockExperimentalVMOptions -H:CCompilerPath="$CC"
+native-image MinimalSwingApp \
+             -H:+UnlockExperimentalVMOptions \
+             -H:CCompilerPath="$CC" \
+             --native-compiler-options="-isysroot ${SDK_PATH}" \
+             --native-compiler-options="-F${SDK_PATH}/System/Library/Frameworks" \
+             --native-compiler-options="-iframework ${SDK_PATH}/System/Library/Frameworks" \
+             --native-compiler-options="-v"


### PR DESCRIPTION
This seems to work insofar as it does get the flags all the way up to
the C compiler, but unfortunarely something does go wrong along the way
as the compiler somehow gets a path with a leading space:

```
$ bin/build
Resolved SDK Path (trimmed): "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
Warning: Environment variable 'MACOSX_DEPLOYMENT_TARGET_FOR_TARGET' is undefined and therefore not available during image build-time.
Warning: Environment variable 'DEVELOPER_DIR_FOR_BUILD' is undefined and therefore not available during image build-time.
Warning: Environment variable 'DEVELOPER_DIR_FOR_TARGET' is undefined and therefore not available during image build-time.
Warning: Environment variable 'MACOSX_DEPLOYMENT_TARGET_FOR_BUILD' is undefined and therefore not available during image build-time.
Warning: Environment variable 'NIX_BUILD_TOP' is undefined and therefore not available during image build-time.
========================================================================================================================
GraalVM Native Image: Generating 'minimalswingapp' (executable)...
========================================================================================================================
[1/8] Initializing...
                                                                                    (0,0s @ 0,07GB)
Error: Error compiling query code (in /var/folders/t8/rqf91gfx4f77klq09d1ptl9h0000gn/T/SVM-11668523353212648257/JNIHeaderDirectives.c). Compiler command '/Library/Developer/CommandLineTools/usr/bin/clang '-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' -F/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks '-iframework /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks' -v -Wall -Werror -Wno-tautological-compare -I/nix/store/sqgz19w406jwdrm42yq3a8qc3f6vdgsn-graalvm-ce-24.0.1/include/darwin -o /var/folders/t8/rqf91gfx4f77klq09d1ptl9h0000gn/T/SVM-11668523353212648257/JNIHeaderDirectives /var/folders/t8/rqf91gfx4f77klq09d1ptl9h0000gn/T/SVM-11668523353212648257/JNIHeaderDirectives.c' output included error: clang: error: no such sysroot directory: ' /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk' [-Werror,-Wmissing-sysroot]
------------------------------------------------------------------------------------------------------------------------
                         0,1s (3,7% of total time) in 5 GCs | Peak RSS: 0,40GB | CPU load: 2,69
========================================================================================================================
Failed generating 'minimalswingapp' after 1,0s.
$
```

So... This is not encouraging.