### PR TITLE
gity/minj: get a non-nixified GraalVM

### DIFF
--- a/dev/gity/java-only/.envrc
+++ b/dev/gity/java-only/.envrc
@@ -1,13 +1,43 @@
-xcode=$(xcode-select -p)
 use nix
-PATH_add $xcode/usr/bin
 PATH_add /usr/bin
 
-export DEVELOPER_DIR=$xcode
-export CC=$xcode/usr/bin/clang
-export CXX=$xcode/usr/bin/clang++
-export SDKROOT=$xcode/SDKs/MacOSX.sdk
-
 watch_file nix/src.json
+
+graalvm_version=24.0.1
+graalvm_sha=875555f6063b4847b617504e8f8a36290a6726770be72388261f6118bcf28f81
+
+cyan() (
+  a='\033[1;36m'
+  b='\033[0m'
+  printf "$a$1$b"
+)
+
+p="$(uname -o)-$(uname -m)"
+case "$p" in
+  "Darwin-arm64")
+    platform=macos-aarch64
+    ;;
+  *)
+    echo "Unsupported platform: '$p'."
+    exit 1
+esac
+
+(
+  exec {flock_fd}>.flock
+  flock $flock_fd
+  lockfile=.graalvm/VERSION
+  if (! [ -f $lockfile ]) || [ "$graalvm_version" != "$(cat $lockfile)" ]; then
+    cyan "\nWe need to download GraalVM. This may take a while, please be patient.\n\n"
+    rm -rf .graalvm
+    d=$(mktemp -d)
+    curl https://download.oracle.com/graalvm/${graalvm_version%%.*}/archive/graalvm-jdk-${graalvm_version}_${platform}_bin.tar.gz > $d/tmp.tar.gz
+    (cd $d; tar xzf tmp.tar.gz)
+    mv $d/graalvm-jdk-${graalvm_version}* .graalvm
+    rm -rf $d
+    echo $graalvm_version > .graalvm/VERSION
+  fi
+)
+
+PATH_add .graalvm/Contents/Home/bin
 
 PATH_add bin

--- a/dev/gity/java-only/.gitignore
+++ b/dev/gity/java-only/.gitignore
@@ -1,3 +1,5 @@
 .envrc.private
 *.class
 /minimalswingapp
+/.flock
+/.graalvm

--- a/dev/gity/java-only/bin/build
+++ b/dev/gity/java-only/bin/build
@@ -4,14 +4,5 @@ set -euo pipefail
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 cd "$DIR/.."
 
-SDK_PATH=$(xcrun --sdk macosx --show-sdk-path | xargs)
-echo "Resolved SDK Path (trimmed): \"$SDK_PATH\""
-
 javac MinimalSwingApp.java
-native-image MinimalSwingApp \
-             -H:+UnlockExperimentalVMOptions \
-             -H:CCompilerPath="$CC" \
-             --native-compiler-options="-isysroot ${SDK_PATH}" \
-             --native-compiler-options="-F${SDK_PATH}/System/Library/Frameworks" \
-             --native-compiler-options="-iframework ${SDK_PATH}/System/Library/Frameworks" \
-             --native-compiler-options="-v"
+native-image MinimalSwingApp

--- a/dev/gity/java-only/shell.nix
+++ b/dev/gity/java-only/shell.nix
@@ -7,7 +7,7 @@ pkgs.mkShell {
     bash
     cacert
     curl
+    flock
     jq
-    graalvm-ce
   ];
 }


### PR DESCRIPTION
Giving up on getting the Nix-provided GraalVM working, I then tried to
get the official one directly from the source. This basically gets me
right back where I started when I ignored the toolchain check: the build
now succeeds, but trying to run the app still fails to find the awt
library.

```
$ ./minimalswingapp
Exception in thread "main" java.lang.UnsatisfiedLinkError: Can't load library: awt | java.library.path = [.]
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.NativeLibraries.loadLibraryRelative(NativeLibraries.java:141)
        at java.base@24.0.1/java.lang.ClassLoader.loadLibrary(ClassLoader.java:100)
        at java.base@24.0.1/java.lang.Runtime.loadLibrary0(Runtime.java:822)
        at java.base@24.0.1/java.lang.System.loadLibrary(System.java:1663)
        at java.desktop@24.0.1/java.awt.Toolkit.loadLibraries(Toolkit.java:1293)
        at java.desktop@24.0.1/java.awt.Toolkit.initStatic(Toolkit.java:1318)
        at java.desktop@24.0.1/java.awt.Toolkit.<clinit>(Toolkit.java:1299)
        at java.desktop@24.0.1/java.awt.EventQueue.invokeLater(EventQueue.java:1257)
        at java.desktop@24.0.1/javax.swing.SwingUtilities.invokeLater(SwingUtilities.java:1415)
        at MinimalSwingApp.main(MinimalSwingApp.java:9)
        at java.base@24.0.1/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
$
```