### PR TITLE
gity/minj: add back env vars

### DIFF
--- a/dev/gity/java-only/.envrc
+++ b/dev/gity/java-only/.envrc
@@ -1,5 +1,8 @@
+xcode=$(xcode-select -p)
 use nix
 PATH_add /usr/bin
+export DEVELOPER_DIR=$xcode
+export SDKROOT=$xcode/SDKs/MacOSX.sdk
 
 watch_file nix/src.json
 


### PR DESCRIPTION
Latest outputs seem to suggest _some_ Nix interference still, which
_could_ be an issue, so I'm setting those env vars back. This did not
help at all.