### PR TITLE
gity/minj: try adding more linker flags

### DIFF
--- a/dev/gity/java-only/bin/build
+++ b/dev/gity/java-only/bin/build
@@ -4,5 +4,20 @@ set -euo pipefail
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 cd "$DIR/.."
 
+SDK_PATH=$(xcrun --sdk macosx --show-sdk-path | xargs)
+echo "Resolved SDK Path: \"$SDK_PATH\""
+
 javac MinimalSwingApp.java
-native-image MinimalSwingApp
+java -agentlib:native-image-agent=config-output-dir=./target/native-image-config MinimalSwingApp
+native-image MinimalSwingApp \
+             -H:+UnlockExperimentalVMOptions \
+             --native-image-info \
+             -H:NativeLinkerOption="-framework" -H:NativeLinkerOption="AppKit" \
+             -H:NativeLinkerOption="-framework" -H:NativeLinkerOption="CoreFoundation" \
+             -H:NativeLinkerOption="-framework" -H:NativeLinkerOption="CoreGraphics" \
+             -H:NativeLinkerOption="-framework" -H:NativeLinkerOption="CoreServices" \
+             -H:NativeLinkerOption="-framework" -H:NativeLinkerOption="Carbon" \
+             -H:NativeLinkerOption="-framework" -H:NativeLinkerOption="ApplicationServices" \
+             -H:NativeLinkerOption="-isysroot" -H:NativeLinkerOption="${SDK_PATH}" \
+             -H:NativeLinkerOption="-L${SDKROOT}/System/Library/Frameworks" \
+             -H:ConfigurationFileDirectories=./target/native-image-config


### PR DESCRIPTION
This does not seem to have any tangible effect: building works, but
running still fails with the same:

```
java.lang.UnsatisfiedLinkError: Can't load library: awt | java.library.path = [.]
```

error. The flags _are_ processed, though, as we can see through `otool`:

```
$ otool -L minimalswingapp
minimalswingapp:
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
        /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 3502.1.255)
        /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
        /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2575.60.5)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 3502.1.255)
        /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (compatibility version 64.0.0, current version 1889.5.3)
        /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1226.0.0)
        /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 170.0.0)
        /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices (compatibility version 1.0.0, current version 65.0.0)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
$
```