### PR TITLE
gity/minj: try liberica

### DIFF
--- a/dev/gity/java-only/.envrc
+++ b/dev/gity/java-only/.envrc
@@ -6,7 +6,7 @@ export SDKROOT=$xcode/SDKs/MacOSX.sdk
 
 watch_file nix/src.json
 
-graalvm_version=24.0.1
+graalvm_version=24.2.1+3
 graalvm_sha=875555f6063b4847b617504e8f8a36290a6726770be72388261f6118bcf28f81
 
 cyan() (
@@ -33,14 +33,15 @@ esac
     cyan "\nWe need to download GraalVM. This may take a while, please be patient.\n\n"
     rm -rf .graalvm
     d=$(mktemp -d)
-    curl https://download.oracle.com/graalvm/${graalvm_version%%.*}/archive/graalvm-jdk-${graalvm_version}_${platform}_bin.tar.gz > $d/tmp.tar.gz
+    curl https://download.bell-sw.com/vm/24.2.1/bellsoft-liberica-vm-openjdk24.0.1+11-24.2.1+3-macos-aarch64.tar.gz > $d/tmp.tar.gz
+    #curl https://download.oracle.com/graalvm/${graalvm_version%%.*}/archive/graalvm-jdk-${graalvm_version}_${platform}_bin.tar.gz > $d/tmp.tar.gz
     (cd $d; tar xzf tmp.tar.gz)
-    mv $d/graalvm-jdk-${graalvm_version}* .graalvm
+    mv $d/*/Contents .graalvm
     rm -rf $d
     echo $graalvm_version > .graalvm/VERSION
   fi
 )
 
-PATH_add .graalvm/Contents/Home/bin
+PATH_add .graalvm/Home/bin
 
 PATH_add bin


### PR DESCRIPTION
No real difference, despite their website saying they support Swing
better than the default distribution. The build again works as expected,
but the the app still does not run. The error message is slightly
different but substantially the same:

```
$ ./minimalswingapp
Exception in thread "main" java.lang.UnsatisfiedLinkError: Can't load library: /Users/gary/dev/misc/dev/gity/java-only/libawt_lwawt.dylib
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.NativeLibraries.loadLibraryAbsolute(NativeLibraries.java:105)
        at java.base@24.0.1/java.lang.ClassLoader.loadLibrary(ClassLoader.java:108)
        at java.base@24.0.1/java.lang.Runtime.load0(Runtime.java:767)
        at java.base@24.0.1/java.lang.System.load(System.java:1624)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.JNIOnLoadFunctionPointer.invoke(JNILibraryInitializer.java)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.JNILibraryInitializer.initialize(JNILibraryInitializer.java:119)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.NativeLibrarySupport.addLibrary(NativeLibrarySupport.java:128)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.NativeLibrarySupport.addLibrary(NativeLibrarySupport.java:84)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.NativeLibraries.loadLibrary0(NativeLibraries.java:147)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.NativeLibraries.loadLibraryRelative(NativeLibraries.java:110)
        at java.base@24.0.1/java.lang.ClassLoader.loadLibrary(ClassLoader.java:100)
        at java.base@24.0.1/java.lang.Runtime.loadLibrary0(Runtime.java:822)
        at java.base@24.0.1/java.lang.System.loadLibrary(System.java:1663)
        at java.desktop@24.0.1/java.awt.Toolkit.loadLibraries(Toolkit.java:1293)
        at java.desktop@24.0.1/java.awt.Toolkit.initStatic(Toolkit.java:1318)
        at java.desktop@24.0.1/java.awt.Toolkit.<clinit>(Toolkit.java:1299)
        at java.desktop@24.0.1/java.awt.EventQueue.invokeLater(EventQueue.java:1257)
        at java.desktop@24.0.1/javax.swing.SwingUtilities.invokeLater(SwingUtilities.java:1415)
        at MinimalSwingApp.main(MinimalSwingApp.java:9)
        at java.base@24.0.1/java.lang.invoke.LambdaForm$DMH/sa346b79c.invokeStaticInit(LambdaForm$DMH)
$
```

I'm giving up on Swing at this point.