### PR TITLE
gity/java-fx: minimal Java FX app, not working

### DIFF
--- a/dev/gity/java-fx/.envrc
+++ b/dev/gity/java-fx/.envrc
@@ -1,0 +1,72 @@
+xcode=$(xcode-select -p)
+use nix
+PATH_add /usr/bin
+export DEVELOPER_DIR=$xcode
+export SDKROOT=$xcode/SDKs/MacOSX.sdk
+
+watch_file nix/src.json
+
+graalvm_version=24.0.1
+graalvm_hash=875555f6063b4847b617504e8f8a36290a6726770be72388261f6118bcf28f81
+
+cyan() (
+  a='\033[1;36m'
+  b='\033[0m'
+  printf "$a$1$b"
+)
+
+p="$(uname -o)-$(uname -m)"
+case "$p" in
+  "Darwin-arm64")
+    platform=macos-aarch64
+    ;;
+  *)
+    echo "Unsupported platform: '$p'."
+    exit 1
+esac
+
+get-dep() (
+  target_dir=$1
+  lockfile=$target_dir/LAST
+  url=$2
+  expected_hash=$3
+  lock_val="$url|$expected_hash"
+  untar=${4:-tar xzf}
+  path=${5:-Contents}
+
+  exec {flock_fd}>.flock
+  flock $flock_fd
+  if (! [ -f $lockfile ]) || [ "$lock_val" != "$(cat $lockfile)" ]; then
+    cyan "\nDownloading dependencies to $target_dir. This may take a while, please be patient.\n\n"
+    rm -rf $target_dir
+    d=$(mktemp -d)
+    curl "$url" > $d/tmp.tar.gz
+    actual_hash=$(sha256sum $d/tmp.tar.gz | cut -f1 -d' ')
+    if ! [ "$expected_hash" = "$actual_hash" ]; then
+      echo "FAIL. Invalid sha for $target_dir."
+      echo "Expected: $expected_sha"
+      echo "Actual:   $actual_sha"
+      exit 1
+    fi
+    (cd $d; $untar tmp.tar.gz)
+    mv $d/*/$path $target_dir
+    rm -rf $d
+    echo "$lock_val" > $lockfile
+  fi
+)
+
+get-dep .graal \
+        https://download.oracle.com/graalvm/${graalvm_version%%.*}/archive/graalvm-jdk-${graalvm_version}_${platform}_bin.tar.gz \
+        $graalvm_hash
+PATH_add .graal/Home/bin
+
+get-dep .javafx \
+        https://download2.gluonhq.com/openjfx/24.0.1/openjfx-24.0.1_osx-aarch64_bin-sdk.zip \
+        859e89235d50247da23bd7f6ba2b5baa46b5ef627795928493e70d9d2d0afa89 \
+        unzip \
+        lib
+
+export FX_HOME="$(pwd)/.javafx"
+
+PATH_add bin
+PATH_add /opt/homebrew/bin

--- a/dev/gity/java-fx/.gitignore
+++ b/dev/gity/java-fx/.gitignore
@@ -1,0 +1,7 @@
+.envrc.private
+/.flock
+/.graal
+/.javafx
+*.class
+/reports
+/minimaljavafxapp

--- a/dev/gity/java-fx/MinimalJavaFXApp.java
+++ b/dev/gity/java-fx/MinimalJavaFXApp.java
@@ -1,0 +1,35 @@
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+public class MinimalJavaFXApp extends Application {
+
+    @Override
+    public void start(Stage stage) {
+        // Create a label with some text
+        Label label = new Label("Hello, JavaFX with GraalVM!");
+
+        // Create a layout pane and add the label to it
+        StackPane root = new StackPane();
+        root.getChildren().add(label);
+
+        // Create a scene with the layout pane and set its size
+        Scene scene = new Scene(root, 320, 240);
+
+        // Set the stage (main window) title
+        stage.setTitle("Minimal JavaFX App");
+
+        // Set the scene on the stage
+        stage.setScene(scene);
+
+        // Show the stage
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        // Launch the JavaFX application
+        launch();
+    }
+}

--- a/dev/gity/java-fx/bin/build
+++ b/dev/gity/java-fx/bin/build
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+cd "$DIR/.."
+
+rm -f *.class minimaljavafxapp
+javac --module-path "$FX_HOME" --add-modules javafx.controls MinimalJavaFXApp.java
+native-image --module-path "$FX_HOME" --add-modules javafx.controls -cp . MinimalJavaFXApp

--- a/dev/gity/java-fx/bin/update-nixpkgs
+++ b/dev/gity/java-fx/bin/update-nixpkgs
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+
+branch=$(jq -r '.branch' "$DIR"/../nix/src.json)
+repo=$(jq -r '.repo' "$DIR"/../nix/src.json)
+owner=$(jq -r '.owner' "$DIR"/../nix/src.json)
+
+commit=$(curl --silent \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              https://api.github.com/repos/$owner/$repo/branches/$branch \
+         | jq -r .commit.sha)
+
+archive_sha=$(nix-prefetch-url \
+                https://github.com/$owner/$repo/archive/$commit.tar.gz \
+                --unpack \
+                2>/dev/null)
+
+jq -n \
+   --arg branch $branch \
+   --arg repo $repo \
+   --arg owner $owner \
+   --arg commit $commit \
+   --arg sha $archive_sha \
+   '{$branch, $repo, $owner, $commit, $sha}' \
+   > "$DIR"/../nix/src.json

--- a/dev/gity/java-fx/nix/nixpkgs.nix
+++ b/dev/gity/java-fx/nix/nixpkgs.nix
@@ -1,0 +1,7 @@
+let
+  spec = builtins.fromJSON (builtins.readFile ./src.json);
+in
+  import (builtins.fetchTarball {
+    url = "https://github.com/${spec.owner}/${spec.repo}/archive/${spec.commit}.tar.gz";
+    sha256 = spec.sha;
+  })

--- a/dev/gity/java-fx/nix/src.json
+++ b/dev/gity/java-fx/nix/src.json
@@ -1,0 +1,7 @@
+{
+  "branch": "nixpkgs-unstable",
+  "repo": "nixpkgs",
+  "owner": "NixOS",
+  "commit": "61c0f513911459945e2cb8bf333dc849f1b976ff",
+  "sha": "0w58g6z5zrqv1bvhpw9v1jx1s9f39wk61wfjrfp3lmqb0w0mcrx7"
+}

--- a/dev/gity/java-fx/shell.nix
+++ b/dev/gity/java-fx/shell.nix
@@ -1,0 +1,14 @@
+let
+  pkgs = import ./nix/nixpkgs.nix {};
+  getFlake = url: (builtins.getFlake url).packages.${pkgs.system}.default;
+in
+pkgs.mkShell {
+  LOCALE_ARCHIVE = if pkgs.stdenv.isLinux then "${pkgs.glibcLocales}/lib/locale/locale-archive" else "";
+  buildInputs = with pkgs; [
+    bash
+    cacert
+    curl
+    flock
+    jq
+  ];
+}


### PR DESCRIPTION
This runs fine under the JVM, and builds fine under `native-image`, but
trying to run the resulting executable yields:

```
$ ./minimaljavafxapp
Exception in thread "main" java.lang.RuntimeException: java.lang.ClassNotFoundException: MinimalJavaFXApp
        at javafx.graphics@24.0.1/javafx.application.Application.launch(Application.java:311)
        at MinimalJavaFXApp.main(MinimalJavaFXApp.java:33)
Caused by: java.lang.ClassNotFoundException: MinimalJavaFXApp
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.ClassForNameSupport.forName(ClassForNameSupport.java:215)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.hub.ClassForNameSupport.forName(ClassForNameSupport.java:183)
        at java.base@24.0.1/java.lang.Class.forName(DynamicHub.java:1509)
        at java.base@24.0.1/java.lang.Class.forName(DynamicHub.java:1497)
        at javafx.graphics@24.0.1/javafx.application.Application.launch(Application.java:299)
        ... 1 more
$
```

This is eerily familiar, though hopefully a missing Java class is going
to be easier to fix than a missing native lib. Also, this is my first
time ever interacting with Java Modules so I have no idea what's going
on and hopefully I'll figure it out.