### PR TITLE
gity/java-fx: trace execution

### DIFF
--- a/dev/gity/java-fx/.gitignore
+++ b/dev/gity/java-fx/.gitignore
@@ -3,5 +3,6 @@
 /.graal
 /.javafx
 *.class
-/reports
+/reports/
 /minimaljavafxapp
+/META-INF/

--- a/dev/gity/java-fx/bin/build
+++ b/dev/gity/java-fx/bin/build
@@ -6,4 +6,6 @@ cd "$DIR/.."
 
 rm -f *.class minimaljavafxapp
 javac --module-path "$FX_HOME" --add-modules javafx.controls MinimalJavaFXApp.java
+java -agentlib:native-image-agent=config-output-dir=./META-INF/native-image \
+     --module-path "$FX_HOME" --add-modules javafx.controls MinimalJavaFXApp.java
 native-image --module-path "$FX_HOME" --add-modules javafx.controls -cp . MinimalJavaFXApp


### PR DESCRIPTION
There seems to be more reflexion going on, so I'm using the tracer to
hopefully discover it all.

This is not great, especially for CI, but let's see how far this gets
me. Next error now is:

```
$ ./minimaljavafxapp
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by com.sun.glass.utils.NativeLibLoader in module javafx.graphics (file:/Users/gary/dev/misc/dev/gity/java-fx/minimaljavafxapp)
WARNING: Use --enable-native-access=javafx.graphics to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

Graphics Device initialization failed for :  es2, sw
Error initializing QuantumRenderer: no suitable pipeline found
java.lang.RuntimeException: java.lang.RuntimeException: Error initializing QuantumRenderer: no suitable pipeline found
        at javafx.graphics@24.0.1/com.sun.javafx.tk.quantum.QuantumRenderer.getInstance(QuantumRenderer.java:272)
        at javafx.graphics@24.0.1/com.sun.javafx.tk.quantum.QuantumToolkit.init(QuantumToolkit.java:233)
        at javafx.graphics@24.0.1/com.sun.javafx.tk.Toolkit.getToolkit(Toolkit.java:251)
        at javafx.graphics@24.0.1/com.sun.javafx.application.PlatformImpl.startup(PlatformImpl.java:274)
        at javafx.graphics@24.0.1/com.sun.javafx.application.PlatformImpl.startup(PlatformImpl.java:154)
        at javafx.graphics@24.0.1/com.sun.javafx.application.LauncherImpl.startToolkit(LauncherImpl.java:652)
        at javafx.graphics@24.0.1/com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:672)
        at javafx.graphics@24.0.1/com.sun.javafx.application.LauncherImpl.lambda$launchApplication$0(LauncherImpl.java:197)
        at java.base@24.0.1/java.lang.Thread.runWith(Thread.java:1460)
        at java.base@24.0.1/java.lang.Thread.run(Thread.java:1447)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)
Caused by: java.lang.RuntimeException: Error initializing QuantumRenderer: no suitable pipeline found
        at javafx.graphics@24.0.1/com.sun.javafx.tk.quantum.QuantumRenderer$PipelineRunnable.init(QuantumRenderer.java:91)
        at javafx.graphics@24.0.1/com.sun.javafx.tk.quantum.QuantumRenderer$PipelineRunnable.run(QuantumRenderer.java:121)
        ... 4 more
Exception in thread "main" java.lang.RuntimeException: No toolkit found
        at javafx.graphics@24.0.1/com.sun.javafx.tk.Toolkit.getToolkit(Toolkit.java:263)
        at javafx.graphics@24.0.1/com.sun.javafx.application.PlatformImpl.startup(PlatformImpl.java:274)
        at javafx.graphics@24.0.1/com.sun.javafx.application.PlatformImpl.startup(PlatformImpl.java:154)
        at javafx.graphics@24.0.1/com.sun.javafx.application.LauncherImpl.startToolkit(LauncherImpl.java:652)
        at javafx.graphics@24.0.1/com.sun.javafx.application.LauncherImpl.launchApplication1(LauncherImpl.java:672)
        at javafx.graphics@24.0.1/com.sun.javafx.application.LauncherImpl.lambda$launchApplication$0(LauncherImpl.java:197)
        at java.base@24.0.1/java.lang.Thread.runWith(Thread.java:1460)
        at java.base@24.0.1/java.lang.Thread.run(Thread.java:1447)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
        at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)
$
```