### PR TITLE
gity/java-fx: explicitly add native libs

### DIFF
--- a/dev/gity/java-fx/bin/build
+++ b/dev/gity/java-fx/bin/build
@@ -5,7 +5,21 @@ DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 cd "$DIR/.."
 
 rm -f *.class minimaljavafxapp
-javac --module-path "$FX_HOME" --add-modules javafx.controls MinimalJavaFXApp.java
+javac --module-path "$FX_HOME" \
+      --add-modules javafx.controls \
+      MinimalJavaFXApp.java
 java -agentlib:native-image-agent=config-output-dir=./META-INF/native-image \
-     --module-path "$FX_HOME" --add-modules javafx.controls MinimalJavaFXApp.java
-native-image --module-path "$FX_HOME" --add-modules javafx.controls -cp . MinimalJavaFXApp
+     --module-path "$FX_HOME" \
+     --add-modules javafx.controls \
+     --enable-native-access=javafx.graphics \
+     MinimalJavaFXApp.java
+native-image --module-path "$FX_HOME" \
+             --add-modules javafx.controls \
+             --enable-native-access=javafx.graphics \
+             -H:NativeLinkerOption=-L"${FX_HOME}" \
+             -H:NativeLinkerOption=-lglass \
+             -H:NativeLinkerOption=-lprism_es2 \
+             -H:NativeLinkerOption=-lprism_common \
+             -H:NativeLinkerOption=-ljavafx_font \
+             -H:NativeLinkerOption=-ljavafx_iio \
+             -cp . MinimalJavaFXApp


### PR DESCRIPTION
Explicitly adding the libraries seems to have done something, in that it
now tries to link them at runtime, but it looks in all the wrong places.
Running the executable now produces:

```
$ ./minimaljavafxapp
dyld[67697]: Library not loaded: /Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/glass/mac/libglass.dylib
  Referenced from: <60F5A88B-9D06-3ECA-BC44-829072E6A9E3> /Users/gary/dev/misc/dev/gity/java-fx/minimaljavafxapp
  Reason: tried: '/Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/glass/mac/libglass.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/glass/mac/libglass.dylib' (no such file), '/Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/glass/mac/libglass.dylib' (no such file)
zsh: abort      ./minimaljavafxapp
$
```