### PR TITLE
gity/java-fx: configure rpath

### DIFF
--- a/dev/gity/java-fx/.gitignore
+++ b/dev/gity/java-fx/.gitignore
@@ -6,3 +6,4 @@
 /reports/
 /minimaljavafxapp
 /META-INF/
+/lib/

--- a/dev/gity/java-fx/bin/build
+++ b/dev/gity/java-fx/bin/build
@@ -4,7 +4,10 @@ set -euo pipefail
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
 cd "$DIR/.."
 
-rm -f *.class minimaljavafxapp
+rm -rf *.class minimaljavafxapp lib
+mkdir lib
+cp "$FX_HOME"/*.dylib lib/
+
 javac --module-path "$FX_HOME" \
       --add-modules javafx.controls \
       MinimalJavaFXApp.java
@@ -12,11 +15,13 @@ java -agentlib:native-image-agent=config-output-dir=./META-INF/native-image \
      --module-path "$FX_HOME" \
      --add-modules javafx.controls \
      --enable-native-access=javafx.graphics \
-     MinimalJavaFXApp.java
+     MinimalJavaFXApp
 native-image --module-path "$FX_HOME" \
              --add-modules javafx.controls \
              --enable-native-access=javafx.graphics \
-             -H:NativeLinkerOption=-L"${FX_HOME}" \
+             -H:NativeLinkerOption=-rpath \
+             -H:NativeLinkerOption=@loader_path/lib \
+             -H:NativeLinkerOption=-L"$DIR/../lib" \
              -H:NativeLinkerOption=-lglass \
              -H:NativeLinkerOption=-lprism_es2 \
              -H:NativeLinkerOption=-lprism_common \


### PR DESCRIPTION
This set of options is meant to give our executable permission to look
for libraries in the `lib` folder relative to the path of the
executable. This does not seem to work at all, though:

```
$ ./minimaljavafxapp
dyld[68251]: Library not loaded: /Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/glass/mac/libglass.dylib
  Referenced from: <FDCFBEAE-F78C-31B6-BE87-AF7C4D15A60A> /Users/gary/dev/misc/dev/gity/java-fx/minimaljavafxapp
  Reason: tried: '/Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/glass/mac/libglass.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/glass/mac/libglass.dylib' (no such file), '/Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/glass/mac/libglass.dylib' (no such file)
zsh: abort      ./minimaljavafxapp
$ otool -L minimaljavafxapp
minimaljavafxapp:
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
        /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 3502.1.255)
        /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
        /Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/glass/mac/libglass.dylib (compatibility version 0.0.0, current version 0.0.0)
        /Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/prismES2/mac/libprism_es2.dylib (compatibility version 0.0.0, current version 0.0.0)
        /Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/prism/mac/libprism_common.dylib (compatibility version 0.0.0, current version 0.0.0)
        /Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/font/mac/libjavafx_font.dylib (compatibility version 0.0.0, current version 0.0.0)
        /Users/jenkins2/jenkins/workspace/OpenJFX-build-target/repo/modules/javafx.graphics/build/libs/iio/mac/libjavafx_iio.dylib (compatibility version 0.0.0, current version 0.0.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 3502.1.255)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
$
```

Ideally we would not have any reference to `/Users/jenkins2` in the
`otool -L` output.