### PR TITLE
gity/java-fx: paths look fixed, but...

### DIFF
--- a/dev/gity/java-fx/bin/build
+++ b/dev/gity/java-fx/bin/build
@@ -8,6 +8,17 @@ rm -rf *.class minimaljavafxapp lib
 mkdir lib
 cp "$FX_HOME"/*.dylib lib/
 
+for dylib in lib/*.dylib; do
+  name=$(basename "$dylib")
+  install_name_tool -id "@rpath/${name}" "$dylib"
+  if otool -L "$dylib" | grep "jenkins2"; then
+    otool -L "$dylib" | grep "jenkins2" | awk '{print $1}' | while read -r old_path; do
+      dep=$(basename "$old_path")
+      install_name_tool -change "$old_path" "@rpath/${dep}" "$dylib"
+    done
+  fi
+done
+
 javac --module-path "$FX_HOME" \
       --add-modules javafx.controls \
       MinimalJavaFXApp.java


### PR DESCRIPTION
I'm really not sure where to go from here. Here's what happens now:

```
$ otool -L minimaljavafxapp
minimaljavafxapp:
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1351.0.0)
        /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 3502.1.255)
        /usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
        @rpath/libglass.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libprism_es2.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libprism_common.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libjavafx_font.dylib (compatibility version 0.0.0, current version 0.0.0)
        @rpath/libjavafx_iio.dylib (compatibility version 0.0.0, current version 0.0.0)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 3502.1.255)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
$ ./minimaljavafxapp
zsh: killed     ./minimaljavafxapp
$
```

That's not a lot of debug output.