### PR TITLE
tm-extractor: copy instead of link

### DIFF
--- a/dev/tm-extractor/src/tm_extractor/core.clj
+++ b/dev/tm-extractor/src/tm_extractor/core.clj
@@ -5,7 +5,7 @@
             [clojure.java.shell :refer [sh]]
             [clojure.data.int-map :as i])
   (:import [java.io File]
-           [java.nio.file Files Paths LinkOption]))
+           [java.nio.file Files Paths LinkOption CopyOption]))
 
 (defn normalize
   [root]
@@ -73,10 +73,11 @@
           (when new?
             (.mkdirs (io/file (str dest "/" bup (.getParent (io/file path)))))
             (try
-              (Files/createLink (Paths/get (str dest "/" bup path) (make-array String 0))
-                                (Paths/get (str src "/" bup path) (make-array String 0)))
+              (Files/copy (Paths/get (str src "/" bup path) (make-array String 0))
+                          (Paths/get (str dest "/" bup path) (make-array String 0))
+                          ^"[Ljava.nio.file.CopyOption;" (make-array CopyOption 0))
               (catch Exception _
-                (print (str "Error linking " path ".\n")))))
+                (print (str "Error copying " path ".\n")))))
           (recur (conj seen? inode)
                  (inc i)
                  (rest files)))))


### PR DESCRIPTION
Something has changed in the way macOS handles Time Machine backups. It
used to be something you could put on a drive next to other things; now
it looks like it occupies the entire drive, making this program pretty
much useless as linking is not possible across filesystems.