### PR TITLE
fs: trampoline solves the issue

### DIFF
--- a/dev/file-sort/bin/t
+++ b/dev/file-sort/bin/t
@@ -1,0 +1,7 @@
+#!/usr/bin/env bb
+
+(require '[babashka.process :as p])
+
+(let [args *command-line-args*]
+  (cond
+    (= ["dups"] args) (p/exec "lein trampoline run ploup")))


### PR DESCRIPTION
For context: `lein trampoline run` differs from `lein run` in that the
former actually does what you'd expect, while the latter does not.

More specifically, `lein run` first starts a JVM with Leiningen running
in it, and then that JVM spawns another JVM and loads the current
project's code inside that. This nesting somehow messes with JLine's
ability to catch the underlying terminal. Instead, JLine is left
interacting with the Leiningen JVM. With `lein trampoline`, the
Leiningen JVM is still started, but, instead of directly starting the
application JVM itself, it instead prepares a launcher for it, which is
then run separately, in the "host" terminal, giving it direct access to
terminal controls. More details [here][0].

[0]: https://www.flyingmachinestudios.com/programming/lein-trampoline/

The code as written actually behaves as desired (one key at a time) when
run either through `java -jar` (after a `lein uberjar`) or through `lein
trampoline run ploup`.

To illustrate this, this PR adds a run script. You may notice I am
trying something new here: instead of the (for-me) traditional `h` Bash
script, I have opted to write this one as a `t` [Babashka] script. I
have no idea whether or not I'll end up liking it, but I thought this
was a good opportunity to try it out.

[Babashka]: https://babashka.org

Now, the obvious question that arises after this revelation is: did I
need JLine at all? It seems plausible that the thing that did not work
was _also_ the `lein` wrapper for the "raw Clojure" version. I'll try
that in a minute.