### PR TITLE
proglang: thread global memory through

### DIFF
--- a/dev/proglang/test/main_test.clj
+++ b/dev/proglang/test/main_test.clj
@@ -79,26 +79,28 @@
      [:assign [:identifier "complex"] [:int "3"]]]))
 
 (deftest pl-eval
-  (are [string result] (= result (second (second (s/eval-pl {} (s/parse (str string "\n"))))))
-    "1+2+3" 6
-    "(1) + (2 * 3)" 7
-    "1  +  2 * 3 " 7
-    "(1  +  2)* 3 " 9))
+  (are [string expected] (let [[env mem actual] (s/eval-pl {} :todo (s/parse (str string "\n")))]
+                           (= expected actual))
+    "1+2+3" [:int 6]
+    "(1) + (2 * 3)" [:int 7]
+    "1  +  2 * 3 " [:int 7]
+    "(1  +  2)* 3 " [:int 9]))
 
 (deftest multiline-expr
-  (are [strings tree] (= tree (second (second (s/eval-pl {} (s/parse (->lines strings))))))
-    ["4" "1+2+3"] 6
-    ["(1+2)" "(1) + (2 * 3)"] 7
-    ["" "6 * 4 " "" "1  +  2 * 3"] 7
-    ["" "" "(1  +  2)* 3 "] 9))
+  (are [strings expected] (let [[env mem actual] (s/eval-pl {} :todo (s/parse (->lines strings)))]
+                            (= expected actual))
+    ["4" "1+2+3"] [:int 6]
+    ["(1+2)" "(1) + (2 * 3)"] [:int 7]
+    ["" "6 * 4 " "" "1  +  2 * 3"] [:int 7]
+    ["" "" "(1  +  2)* 3 "] [:int 9]))
 
 (deftest files
   (are [path result] (= result (s/run-file (str "test-resources/" path ".py")))
-    "plain-sum" 42
-    "parens" 154
-    "multi-line" 12
-    "assign" 42
-    "thrice" 31
-    "global-side-effect" 12
-    "global-shadowing" 2
-    "global-unaffected" 5))
+    "plain-sum" [:int 42]
+    "parens" [:int 154]
+    "multi-line" [:int 12]
+    "assign" [:int 42]
+    "thrice" [:int 31]
+    "global-side-effect" [:int 12]
+    "global-shadowing" [:int 2]
+    "global-unaffected" [:int 5]))


### PR DESCRIPTION
This is obviously not doing anything yet as `mem` is never read or set.
But it's getting threaded through everywhere, which is a nice first
step.

The goal is to have a system where:

- Environments are "per function", or more precisely per function call,
  i.e. closures remember the environment they were created in, and
  function application creates a new environment.
- Environments are maps from identifier to "memory location".
- The global memory map maps "memory location" to value.

I'm still not entirely sure what "memory location" should be, though the
biggest issue I'm seeing right now is garbage collection in the global
memory. With the current approach (env is a map of identifier to atom),
values are released by the host GC as soon as the corresponding
environment gets discarded. With this new approach, I lose that: the
environment would still be discarded, but the entry in the global memory
map wouldn't. [WeakHashMaps] may help, I suppose, though I think I'd
rather try out my own GC.

[WeakHashMaps]: https://docs.oracle.com/javase/8/docs/api/java/util/WeakHashMap.html