### PR TITLE
proglang: nested fib works

### DIFF
--- a/dev/proglang/test-resources/fib.py
+++ b/dev/proglang/test-resources/fib.py
@@ -1,0 +1,10 @@
+def fib(n):
+  if n == 0:
+    return 1
+  else:
+    if n == 1:
+      return 1
+    else:
+      return fib(n + -2) + fib(n + -1)
+
+fib(10)

--- a/dev/proglang/test/main_test.clj
+++ b/dev/proglang/test/main_test.clj
@@ -139,4 +139,5 @@
     "global-side-effect" [:int 12]
     "global-shadowing" [:int 2]
     "global-unaffected" [:int 5]
-    "fact" [:int 3628800]))
+    "fact" [:int 3628800]
+    "fib" [:int 89]))


### PR DESCRIPTION
But this doesn't:

```python
def fib(n):
  if n == 0:
    return 1
  if n == 1:
    return 1
  return fib(n + -2) + fib(n + -1)

fib(10)
```

because, I think, `return` is currently not breaking out of the
enclosing function, so it gets to the last line regardless, and
StackOVerflows past `n == 0`.