### PR TITLE
proglang: fix shell

### DIFF
--- a/dev/proglang/bin/h
+++ b/dev/proglang/bin/h
@@ -12,6 +12,7 @@ _help() (
   echo "  h test        Watches src and test directories, and runs \`clj -X:test\`"
   echo "                on each change."
   echo "  h repl        Starts a Cider REPL."
+  echo "  h shell       Starts a proglang shell."
 )
 
 _test() (
@@ -22,12 +23,13 @@ _repl() (
   clj -M:cider-clj
 )
 
+_shell() (
+  clj -M -m main
+)
+
 case $1 in
-  repl)
-    _repl
-    ;;
-  test)
-    _test
+  repl|test|shell)
+    _$1
     ;;
   *)
     _help

--- a/dev/proglang/test/main_test.clj
+++ b/dev/proglang/test/main_test.clj
@@ -104,7 +104,7 @@
       [:int "1"]
       [:app [:identifier "fact"] [:int "3"]]]]))
 
-#_(deftest pl-eval
+(deftest pl-eval
   (are [string expected] (let [[env mem stack actual] (s/eval-pl (s/parse (str string "\n")))]
                            #_(prn [expected actual])
                            (= expected actual))


### PR DESCRIPTION
Here's a sample session:

```
$ h shell
>  a = 2
=>  nil
>  a * 3
=>  [:int 6]
>  :env
{"print" 0, "a" 1}
>  :mem
{:next-addr 2,
 :mem {0 [:fn ["s"] [:S [:print [:identifier "s"]] [:return [:int "0"]]]
{}], 1 [:int 2]}
>  def fib(n):
...  if n == 0:
...    return 1
...  if n == 1:
...    return 1
...  return fib(n + -1) + fib (n + -2)
...
=>  nil
>  :env
{"print" 0, "a" 1, "fib" 2}
>  :mem
{:next-addr 3,
 :mem {0 [:fn ["s"] [:S [:print [:identifier "s"]] [:return [:int "0"]]]
{}], 1 [:int 2], 2 [:fn ("n") (:S [:if [:equal [:identifier "n"] [:int
"0"]] ([:return [:int "1"]])] [:if [:equal [:identifier "n"] [:int "1"]]
([:return [:int "1"]])] [:return [:sum [:app [:identifier "fib"] [:sum
[:identifier "n"] [:int "-1"]]] [:app [:identifier "fib"] [:sum
[:identifier "n"] [:int "-2"]]]]]) {"print" 0, "a" 1, "fib" 2}]}
>  fib(25)
=>  [:int 121393]
>  :env
{"print" 0, "a" 1, "fib" 2}
>  :mem
{:next-addr 242788,
 :mem <:count 242788, :sample {141335 [:int 1], 174959 [:int 1], 51129
[:int 3], 29697 [:int 1], 28517 [:int 1], 219976 [:int 2], 94329 [:int
3], 141661 [:int 1], 75099 [:int 1], 205240 [:int 2]}>}
>  quit
Bye!
$
```

That last result almost makes me want to start looking into GC.