### PR TITLE
proglang: use vatch

### DIFF
--- a/dev/proglang/deps.edn
+++ b/dev/proglang/deps.edn
@@ -1,6 +1,7 @@
 {:deps
  {instaparse/instaparse {:mvn/version "1.5.0"}
-  io.github.gaverhae/clonad {:git/sha "1a02ffc84d1f60dd74dc8c1c8616c1a3d080b74f"}}
+  io.github.gaverhae/clonad {:git/sha "1a02ffc84d1f60dd74dc8c1c8616c1a3d080b74f"}
+  io.github.gaverhae/vatch {:git/sha "fbd5cb1a536034fc97d1f998f5c40a299e6df753"}}
  :aliases
  {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.9" :git/sha "e405aac"}}
           :ns-default build}

--- a/dev/proglang/test/main_test.clj
+++ b/dev/proglang/test/main_test.clj
@@ -140,6 +140,7 @@
 
 (deftest files
   (are [path result] (let [s (with-out-str (s/run-file (str "test-resources/" path ".py")))]
+                       #_(prn [:exp result :act (string/split-lines s)])
                        (= result (string/split-lines s)))
     "plain-sum" ["42"]
     "parens" ["154"]
@@ -184,8 +185,8 @@
                                         "  return fib(n + -1) + fib(n + -2)"
                                         "fib(25)"]))))
   (with-out-str (time (s/mrun-envs fib)))
-"\"Elapsed time: 3215.4995 msecs\"\n"
+"\"Elapsed time: 3769.785542 msecs\"\n"
   (with-out-str (time (binding [s/+enable-gc+ true]
                         (s/mrun-envs fib))))
-"\"Elapsed time: 5510.669833 msecs\"\n"
+"\"Elapsed time: 5483.278375 msecs\"\n"
 )


### PR DESCRIPTION
Well, this was a lot harder to debug than I expected. There is a subtle
difference in semantics between clonad's `match` and `vatch`: `vatch`
explicitly checks that the number of elements matches, whereas `match`
does not care.

Debugging this was made harder by the fact that there is no error when
you fall through a `vatch`; it just returns `nil`.