### PR TITLE
proglang: BROKEN more generic way to handle effects

### DIFF
--- a/dev/proglang/src/main.clj
+++ b/dev/proglang/src/main.clj
@@ -169,9 +169,10 @@
       [:print a] [[:pure nil] (conj output a)]
       [:bind mv f] (vatch mv
                      [:pure a] [(f a) output]
-                     [:print a] [(f nil) (conj output a)]
                      [:bind i-mv i-f] (let [[i-mv output] (step i-mv output)]
-                                        [:bind i-mv f])))))
+                                        [:bind i-mv f])
+                     otherwise (let [[mv output] (step mv output)]
+                                 [[:bind mv f] output]))))
 
   (defn run-parallel
     [mvs]


### PR DESCRIPTION
In this context, effects are all the monadic operations that are neither
`:pure` nor `:bind`, so in this case specifically `:print`. But writing
it this way means I can resolve all of the effects once, at the
"top-level" of `step`, rather than redoing them in the `bind` case as I
did previously.

The caveat of course is that effects need to eventually reach `:pure`
(or, I suppose, `:bind`, though that seems less likely) after successive
applications of `step`. I believe that's a fair assumption.