### PR TITLE
proglang: BROKEN don't lose i-f

### DIFF
--- a/dev/proglang/src/main.clj
+++ b/dev/proglang/src/main.clj
@@ -169,8 +169,8 @@
       [:print a] [[:pure nil] (conj output a)]
       [:bind mv f] (vatch mv
                      [:pure a] [(f a) output]
-                     [:bind i-mv i-f] (let [[i-mv output] (step i-mv output)]
-                                        [:bind i-mv f])
+                     [:bind _ _] (let [[mv output] (step mv output)]
+                                        [[:bind mv f] output])
                      otherwise (let [[mv output] (step mv output)]
                                  [[:bind mv f] output]))))
 


### PR DESCRIPTION
This feels better as a way to handle `mv` being a `:bind`.
Interestingly, there is now no difference between `:bind` and effects in
this code, making `:pure` the only case that requires special treatment.

This feels like a cool insight. :thinking: