### PR TITLE
proglang: BROKEN remove special handling of `:bind`

### DIFF
--- a/dev/proglang/src/main.clj
+++ b/dev/proglang/src/main.clj
@@ -169,8 +169,6 @@
       [:print a] [[:pure nil] (conj output a)]
       [:bind mv f] (vatch mv
                      [:pure a] [(f a) output]
-                     [:bind _ _] (let [[mv output] (step mv output)]
-                                        [[:bind mv f] output])
                      otherwise (let [[mv output] (step mv output)]
                                  [[:bind mv f] output]))))
 


### PR DESCRIPTION
This makes sense. If I want to run `[:bind mv f]` step-wise, either `mv`
has been reduced to a `:pure` value and I can apply `f` to it, ir it's
not and I need to `step` the internal `mv` first.

Not sure why that felt so murky yesterday. It seems so clear to me now.