### PR TITLE
g/g-1: unblur ghost svg on Safari

### DIFF
--- a/games/2025-08-14-game-1/style.css
+++ b/games/2025-08-14-game-1/style.css
@@ -25,6 +25,16 @@ html, body, #app, main {
   user-select: none;
 }
 
+.cgv-entity {
+  -webkit-transform: translate(calc(var(--ox) * 1vmin),
+                               calc(var(--oy) * -1vmin))
+                     translateX(calc(var(--x) * 1vmin))
+                     translateY(calc(var(--y) * -1vmin))
+                     scale(var(--s))
+                     scale(var(--sx), var(--sy))
+                     rotate(var(--r));
+}
+
 .icon {
   width: 48px;
   height: 48px;


### PR DESCRIPTION
For whatever reason, on (my) Safari the ghost gets blurry as soon as the
`translateZ` operation is applied. This is copy-pasting the `cgv-entity`
class's `transform` operation from [css-gameview], renaming it
`-webkit-transform` so as to not affect other browsers, and removing the
`translateZ` component.

The main downside of this approach is that I am no longer able to
translate along the Z axis, which I don't think I'd wanted to do in a 2d
game anyway.

[css-gameview]: https://github.com/chr15m/css-gameview