### PR TITLE
proglang: include lisp in parens tests

### DIFF
--- a/dev/proglang/test/main_test.clj
+++ b/dev/proglang/test/main_test.clj
@@ -65,11 +65,16 @@
     [:list [:symbol "+"] [:list [:symbol "*"] [:int "2"] [:int "3"]] [:int "1"]]))
 
 (deftest parens
-  (are [string tree] (= tree (first (s/parse-string string :start :expr)))
+  (are [string tree l-string l-tree] (and (= tree (first (s/parse-string string :start :expr)))
+                                          (= [l-tree] (l/parse-string l-string :start :expr)))
     "1 + (2 * 3)" [:sum [:int "1"] [:product [:int "2"] [:int "3"]]]
+    "(+ 1 (* 2 3))" [:list [:symbol "+"] [:int "1"] [:list [:symbol "*"] [:int "2"] [:int "3"]]]
     "(1 + 2) * 3" [:product [:sum [:int "1"] [:int "2"]] [:int "3"]]
+    "(* (+ 1 2) 3)" [:list [:symbol "*"] [:list [:symbol "+"] [:int "1"] [:int "2"]] [:int "3"]]
     "(1 + 2 * 3)" [:sum [:int "1"] [:product [:int "2"] [:int "3"]]]
-    "(1) + (2 * 3)" [:sum [:int "1"] [:product [:int "2"] [:int "3"]]]))
+    "(+ 1 (* 2 3))" [:list [:symbol "+"] [:int "1"] [:list [:symbol "*"] [:int "2"] [:int "3"]]]
+    "(1) + (2 * 3)" [:sum [:int "1"] [:product [:int "2"] [:int "3"]]]
+    "(+ 1 (* 2 3))" [:list [:symbol "+"] [:int "1"] [:list [:symbol "*"] [:int "2"] [:int "3"]]]))
 
 (defn ->lines
   [strings]


### PR DESCRIPTION
Obviously less relevant. Still, felt worth including.