### PR TITLE
proglang/lisp: introduce a monad

### DIFF
--- a/dev/proglang/test/main_test.clj
+++ b/dev/proglang/test/main_test.clj
@@ -241,7 +241,7 @@
 
 (deftest pl-eval
   (let [p (fn [s] (first (s/eval-pl (s/parse (str s "\n")))))
-        l (fn [s] (first (l/m-eval (l/parse (str s "\n")))))]
+        l (fn [s] (first (l/eval-pl (l/parse (str s "\n")))))]
     (is (= [:int 6] (p "1+2+3")))
     (is (= [:v/int 6] (l "(+ 1 2 3)")))
     (is (= [:int 7] (p "(1) + (2 * 3)")))


### PR DESCRIPTION
Hopefully this time the gain is a bit more visible: we do get more
pieces (`m-run` and `m-eval` vs. just `m-eval`), but each piece is, if
we "believe" in monads and are able to read `monad` calls, simpler: the
threading through of `state` through `reduce` has disappeared from
`m-eval`. Intead of "doing" the interpretation, `m-eval` now returns a
plan for later interpretation by `m-run`, in a sense.

`m-run` at this point encodes two "operations": sequencing, threading
state, in `:bind`, and failure, through `:assert`.