### PR TITLE
proglang/lisp: introduce a reader

### DIFF
--- a/dev/proglang/src/lisp.clj
+++ b/dev/proglang/src/lisp.clj
@@ -14,6 +14,17 @@
      bool := 'true' | 'false'
      <ws> = <#'\\s'>"))
 
+(defn quoted
+  [v]
+  (vatch v
+    [:int s] [:v/int (parse-long s)]))
+
+(defn read-form
+  [s]
+  (vatch (parse s)
+    [:S v] (quoted v)
+    otherwise [:error/not-a-form s]))
+
 (def init-state
   {:top-level {}})
 

--- a/dev/proglang/test/main_test.clj
+++ b/dev/proglang/test/main_test.clj
@@ -4,6 +4,12 @@
             [clojure.string :as string]
             [expectations :refer [expect]]))
 
+;; Lisp Reader
+
+(let [l (fn [s] (l/read-form s))]
+  (expect [:v/int 4]
+          (l "4")))
+
 ;; Basic expressions
 
 (let [p (fn [s] (s/parse-string s :start :expr))


### PR DESCRIPTION
The traditional Lisp architecture is to have a separate reader. We're
cheating a bit here (well, not yet, but planning to) in that instaparse
already gives us data structures, but we're going to move towards having
`m-eval` work over values, rather than parse trees. In practice, for
now, that mostly means it'll switch to keywords with `v` as a prefix.

Here, though, the main reason I'm doing this is because I want to
implement `let` with a Clojure-like structure, meaning I need vectors,
so I wanted to test vectors on their own. Which lead me to realize the
distinction I'd started to make between `:int` and `:v/int` does not
really work long-term. So turning `:int` into `:v/int` is now going to
be the job of the reader (`read-form`), rather than `ml-eval`.