### PR TITLE
proglang/lisp: rewrite eval in terms of reader

### DIFF
--- a/dev/proglang/test/main_test.clj
+++ b/dev/proglang/test/main_test.clj
@@ -255,7 +255,7 @@
 ;; Evaluation of simple expressions.
 
 (let [p (fn [s] (first (s/eval-pl (s/parse (str s "\n")))))
-      l (fn [s] (first (l/eval-pl (l/parse (str s "\n")))))]
+      l (fn [s] (l/eval-forms (l/read-forms (str s "\n"))))]
   (expect [:int 6] (p "1+2+3"))
   (expect [:v/int 6] (l "(+ 1 2 3)"))
 
@@ -278,13 +278,13 @@
   (expect [:bool false] (p "True == False" ))
   (expect [:v/bool false] (l "(= true false)"))
 
-  (expect [:error "Tried to add non-numeric values."]
+  (expect [:m/error "Tried to add non-numeric values."]
           (l "(+ 1 true)")))
 
 ;; Evaluation of multi-line programs.
 
 (let [p (fn [s] (first (s/eval-pl (s/parse (->lines s)))))
-      l (fn [s] (first (l/eval-pl (l/parse (->lines s)))))]
+      l (fn [s] (l/eval-forms (l/read-forms (->lines s))))]
   (expect [:int 6]
           (p ["4"
               "1+2+3"]))


### PR DESCRIPTION
It's not a huge gain, but adding this intermediate level of abstraction
highlights the fact that `eval` really only cares about symbols and
lists, and leaves the rest unchanged.

Well, actually, that's not entirely correct. Writing this, I just
realized as of this commit we would fail to evaluate `[(+ 1 2) 3]`.
Anyhoo.

The biggest disappointment of this piece of work is my realization that
I cannot namespace the keywords representing monadic values, because all
of the `:bind` (and some of the `:pure`) values are generated by
`monad`.